### PR TITLE
Feature/allow usage of node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.8.148",
+  "version": "0.8.149",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.8.146",
+  "version": "0.8.147",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.8.147",
+  "version": "0.8.148",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.8.149",
+  "version": "0.8.150",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/cli/create-app.js
+++ b/src/cli/create-app.js
@@ -1,0 +1,6 @@
+export const description = 'Bootstrap React Native app';
+export const command = 'create app';
+export function handler() {
+  console.log("We're just polishing the app creating process.\nFor now, use Shoutem Builder to create app: " +
+    'https://builder.shoutem.com'.bold.white);
+}

--- a/src/cli/run-android.js
+++ b/src/cli/run-android.js
@@ -25,6 +25,11 @@ export const builder = yargs => {
         alias: 'd',
           description: 'run app on a specific device',
           requiresArg: true
+      },
+      clean: {
+        alias: 'c',
+        description: 'forces the client platform to be cleaned up, configured, linked and compiled from scratch',
+        type: 'boolean'
       }
     })
     .usage(`shoutem ${command} [options]\n\n${description}`);

--- a/src/cli/run-ios.js
+++ b/src/cli/run-ios.js
@@ -31,6 +31,11 @@ export const builder = yargs => {
         alias: 's',
         description: 'run app on a specific simulator',
         type: 'string'
+      },
+      clean: {
+        alias: 'c',
+        description: 'forces the client platform to be cleaned up, configured, linked and compiled from scratch',
+        type: 'boolean'
       }
     })
     .usage(`shoutem ${command} [options]\n\n${description}`);

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -26,6 +26,11 @@ export const builder = yargs => {
         alias: 's',
         description: 'display smaller ASCII QR code which could be unreadable in some fonts',
         type: 'boolean'
+      },
+      clean: {
+        alias: 'c',
+        description: 'forces the client platform to be cleaned up, configured, linked and compiled from scratch',
+        type: 'boolean'
       }
     })
     .usage(`shoutem ${command} [options]\n\n${description}`);

--- a/src/extension/platform-manager.js
+++ b/src/extension/platform-manager.js
@@ -69,7 +69,7 @@ async function syncApp(path, opts) {
 
   const oldAppState = await getOldApplicationState(path, appId);
 
-  if (_.isEqual(currentAppState, oldAppState)) {
+  if (!opts.clean && _.isEqual(currentAppState, oldAppState)) {
     await platform.runShoutemWatcher(path);
     return null;
   }

--- a/src/extension/platform-manager.js
+++ b/src/extension/platform-manager.js
@@ -70,7 +70,7 @@ async function syncApp(path, opts) {
   const oldAppState = await getOldApplicationState(path, appId);
 
   if (_.isEqual(currentAppState, oldAppState)) {
-    platform.runShoutemWatcher(path);
+    await platform.runShoutemWatcher(path);
     return null;
   }
 

--- a/src/extension/platform.js
+++ b/src/extension/platform.js
@@ -6,9 +6,8 @@ import { getLinkedDirectories } from './linker';
 import { AppManagerClient } from '../clients/app-manager';
 import decompressUri from './decompress';
 import cliUrls from '../../config/services';
-import { writeJsonFile } from './data';
+import { writeJsonFile, readJsonFile } from './data';
 import * as npm from './npm';
-import { readJsonFile } from './data';
 import { ensureUserIsLoggedIn } from '../commands/login';
 import { ensureYarnInstalled } from './yarn';
 import * as reactNative from './react-native';
@@ -157,8 +156,12 @@ export async function runPlatform(platformDir, { platform, device, simulator, re
   return await npm.run(platformDir, 'run', runOptions);
 }
 
-export function runShoutemWatcher(platformDir) {
-  const watcherPath = path.join(platformDir, 'scripts', 'helpers', 'run-watch-in-new-window.js');
-  const runWatchInNewWindow = require(watcherPath);
-  runWatchInNewWindow();
+export async function runShoutemWatcher(platformDir) {
+  const { workingDirectories } = await readJsonFile(path.join(platformDir, 'config.json')) || {};
+
+  if ((workingDirectories || []).length > 0) {
+    const watcherPath = path.join(platformDir, 'scripts', 'helpers', 'run-watch-in-new-window.js');
+    const runWatchInNewWindow = require(watcherPath);
+    runWatchInNewWindow();
+  }
 }

--- a/src/extension/platform.js
+++ b/src/extension/platform.js
@@ -11,7 +11,6 @@ import * as npm from './npm';
 import { readJsonFile } from './data';
 import { ensureUserIsLoggedIn } from '../commands/login';
 import { ensureYarnInstalled } from './yarn';
-import { ensureNodeVersion } from './node';
 import * as reactNative from './react-native';
 import * as analytics from './analytics';
 
@@ -69,7 +68,6 @@ export async function createMobileConfig(platformDir, opts) {
 
 export async function preparePlatform(platformDir, mobileConfig) {
   await ensureYarnInstalled();
-  await ensureNodeVersion();
   await reactNative.ensureInstalled();
 
   const configPath = path.join(platformDir, 'config.json');

--- a/templates/init/template-initialization.js
+++ b/templates/init/template-initialization.js
@@ -1,14 +1,16 @@
 const path = require('path');
 const install = require('../../src/extension/npm').install;
+const generateExtensionJs = require('../../src/extension/ext-js-generator').generateExtensionJs;
 require('colors');
 
 module.exports = (_, extPath, { extJson }) => {
-  console.log('Initializing extension:'.green.bold);
-  console.log('Installing packages for server...'.green.bold);
-  return install(path.join(extPath, extJson.name, 'server'))
+  return generateExtensionJs(path.join(extPath, extJson.name))
+    .then(() => {
+      console.log('Initializing extension:'.green.bold);
+      console.log('Installing packages for server...'.green.bold);
+    })
+    .then(() => install(path.join(extPath, extJson.name, 'server')))
     .then(() => console.log('Installing packages for app...'.green.bold))
     .then(() => install(path.join(extPath, extJson.name, 'app')))
-    .then(() => {
-      console.log('Packages installed.');
-    });
+    .then(() => console.log('Packages installed.'));
 };

--- a/templates/init/template-initialization.js
+++ b/templates/init/template-initialization.js
@@ -10,7 +10,9 @@ module.exports = (_, extPath, { extJson }) => {
       console.log('Installing packages for server...'.green.bold);
     })
     .then(() => install(path.join(extPath, extJson.name, 'server')))
-    .then(() => console.log('Installing packages for app...'.green.bold))
-    .then(() => install(path.join(extPath, extJson.name, 'app')))
+    .then(() => {
+      console.log('Installing packages for app...'.green.bold);
+      return install(path.join(extPath, extJson.name, 'app'));
+    })
     .then(() => console.log('Packages installed.'));
 };

--- a/templates/init/{{extJson.name}}/app/extension.js
+++ b/templates/init/{{extJson.name}}/app/extension.js
@@ -1,9 +1,0 @@
-// This file is managed by Shoutem CLI
-// You should not change it
-import pack from './package.json';
-
-export const screens = {};
-
-export function ext(resourceName) {
-  return resourceName ? `${pack.name}.${resourceName}` : pack.name;
-}

--- a/templates/init/{{extJson.name}}/app/index.js
+++ b/templates/init/{{extJson.name}}/app/index.js
@@ -4,3 +4,4 @@
 import * as extension from './extension.js';
 
 export const screens = extension.screens;
+export const themes = extension.themes;


### PR DESCRIPTION
A bunch of small fixes:
- allows the run* group of commands be used with both node 6 and node 7
- adds a clean flag for run* commands
- runs shoutem watcher if it's not started by the client
- generates app/extension.js file on `shoutem init`
- exports theme from app/extension.js through app/index.js on `shoutem init`