### PR TITLE
Fixed theme template link.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -6,8 +6,8 @@ import {instantiateExtensionTemplate} from "../services/extension-template";
 import {offerChanges} from "../services/diff";
 
 const themeUrls = {
-  theme: 'https://raw.githubusercontent.com/shoutem/extensions/master/shoutem-rubicon-theme/app/themes/Rubicon.js',
-  variables: 'https://raw.githubusercontent.com/shoutem/extensions/master/shoutem-rubicon-theme/server/primeThemeVariables.json'
+  theme: 'https://raw.githubusercontent.com/shoutem/extensions/master/shoutem.rubicon-theme/app/themes/Rubicon.js',
+  variables: 'https://raw.githubusercontent.com/shoutem/extensions/master/shoutem.rubicon-theme/server/primeThemeVariables.json'
 };
 
 async function promptThemeDetails(themeName) {


### PR DESCRIPTION
Fixed outdated template theme link that pointed to old version of repo which had `shoutem-extName` instead of `shoutem.extName`.