### PR TITLE
Feature/seext 8022 cli should use v5 auth service for app token creation

### DIFF
--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -30,7 +30,7 @@ export class UnauthorizedError {
 }
 
 const tokensUrl = new URI(services.authService).segment('/v1/auth/tokens').toString();
-const appAccessTokenUrl = new URI(services.legacyService).segment('/v1/auth/tokens').toString();
+const appAccessTokenUrl = new URI(services.authService).segment('/v1/tokens').toString();
 
 function getBasicAuthHeaderValue(email, password) {
   return 'Basic ' + new Buffer(`${email}:${password}`).toString('base64');
@@ -66,6 +66,7 @@ export async function createAppAccessToken(appId, refreshToken) {
     }
   };
 
+  console.log("apAccessTokenUrl is:", appAccessTokenUrl);
   const { token } = await post(appAccessTokenUrl, body, {
     headers: {
       Authorization: `Bearer ${refreshToken}`

--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -29,7 +29,7 @@ export class UnauthorizedError {
   }
 }
 
-const tokensUrl = new URI(services.authService).segment('/v1/auth/tokens').toString();
+const tokensUrl = new URI(services.authService).segment('/v1/tokens').toString();
 const appAccessTokenUrl = new URI(services.authService).segment('/v1/tokens').toString();
 
 function getBasicAuthHeaderValue(email, password) {

--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -3,8 +3,6 @@ import { post } from './json-api-client';
 import services from '../../config/services';
 import * as cache from '../services/cache-env';
 import * as logger from '../services/logger';
-import * as jsonApi from './json-api-client';
-
 
 export class AuthServiceError {
   /*
@@ -31,8 +29,8 @@ export class UnauthorizedError {
   }
 }
 
-const tokensUrl = new URI(services.authService).segment('/v1/tokens').toString();
-const appAccessTokenUrl = new URI(services.authService).segment('/v1/tokens').toString();
+const tokensUrl = new URI(services.authService).segment('/v1/auth/tokens').toString();
+const appAccessTokenUrl = new URI(services.authService).segment('/v1/auth/tokens').toString();
 
 function getBasicAuthHeaderValue(email, password) {
   return 'Basic ' + new Buffer(`${email}:${password}`).toString('base64');
@@ -68,11 +66,9 @@ export async function createAppAccessToken(appId, refreshToken) {
     }
   };
 
-  const { token } = await jsonApi.post(appAccessTokenUrl, null, {
-    body,
+  const { token } = await post(appAccessTokenUrl, body, {
     headers: {
-      Authorization: `Bearer ${refreshToken}`,
-      Accept: 'application/vnd.api+json',
+      Authorization: `Bearer ${refreshToken}`
     }
   });
 

--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -3,6 +3,8 @@ import { post } from './json-api-client';
 import services from '../../config/services';
 import * as cache from '../services/cache-env';
 import * as logger from '../services/logger';
+import * as jsonApi from './json-api-client';
+
 
 export class AuthServiceError {
   /*
@@ -66,9 +68,11 @@ export async function createAppAccessToken(appId, refreshToken) {
     }
   };
 
-  const { token } = await post(appAccessTokenUrl, body, {
+  const { token } = await jsonApi.post(appAccessTokenUrl, null, {
+    body,
     headers: {
-      Authorization: `Bearer ${refreshToken}`
+      Authorization: `Bearer ${refreshToken}`,
+      Accept: 'application/vnd.api+json',
     }
   });
 

--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -66,7 +66,6 @@ export async function createAppAccessToken(appId, refreshToken) {
     }
   };
 
-  console.log("apAccessTokenUrl is:", appAccessTokenUrl);
   const { token } = await post(appAccessTokenUrl, body, {
     headers: {
       Authorization: `Bearer ${refreshToken}`


### PR DESCRIPTION
Makes CLI generate app access token script via v5 auth service instead of legacy service.