### PR TITLE
Hotfix/0.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "prepare": "npm run build",
+    "preinstall": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "preinstall": "npm run build",
+    "prepare": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -112,12 +112,13 @@ async function offerDevNameSync(extensionDir) {
 
 export default async function shoutemPack(dir, options) {
   const components = ['app', 'server'];
+  const hasCloud = await hasCloudComponent(dir);
 
-  if (hasCloudComponent(dir)) {
+  if (hasCloud) {
     components.push('cloud');
   }
 
-  const packedDirectories = components.map(d => {console.log(derp)});
+  const packedDirectories = components.map(d => path.join(dir, d));
 
   if (!await hasExtensionsJson(dir)) {
     throw new Error(`${dir} cannot be packed because it has no extension.json file.`);

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -111,7 +111,10 @@ async function offerDevNameSync(extensionDir) {
 }
 
 export default async function shoutemPack(dir, options) {
-  const packedDirectories = ['app', 'server', 'cloud'].map(d => path.join(dir, d));
+  const components = ['app', 'server'];
+  const resolvedComponents = hasCloudComponent(dir) ? components.push('cloud') : components;
+  const packedDirectories = resolvedComponents.map(d => path.join(dir, d));
+
 
   if (!await hasExtensionsJson(dir)) {
     throw new Error(`${dir} cannot be packed because it has no extension.json file.`);

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -112,9 +112,12 @@ async function offerDevNameSync(extensionDir) {
 
 export default async function shoutemPack(dir, options) {
   const components = ['app', 'server'];
-  const resolvedComponents = hasCloudComponent(dir) ? components.push('cloud') : components;
-  const packedDirectories = resolvedComponents.map(d => path.join(dir, d));
 
+  if (hasCloudComponent(dir)) {
+    components.push('cloud');
+  }
+
+  const packedDirectories = components.map(d => {console.log(derp)});
 
   if (!await hasExtensionsJson(dir)) {
     throw new Error(`${dir} cannot be packed because it has no extension.json file.`);


### PR DESCRIPTION
Resolves error messages and publishing fail when an extension does not contain `cloud` directory.

Will switch `preinstall` back to `prepare` and bump version before merging into master and dev once approved.