### PR TITLE
Hotfix/0.13.6

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+# ignore dependencies
+/node_modules
+
+# ignore all logs
+*.log
+
+# OSX stuff
+.DS_Store
+
+.idea/
+*.tgz
+
+.update-theme

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "prepare": "npm run build",
+    "preinstall": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "preinstall": "npm run build",
+    "prepare": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "child-process-promise": "2.2.0",
     "cli-spinner": "0.2.6",
     "colors": "1.1.2",
-    "command-exists": "1.0.2",
+    "command-exists": "~1.2.4",
     "decamelize": "^1.2.0",
     "decompress": "4.0.0",
     "diff": "^3.3.1",


### PR DESCRIPTION
- adds `.npmignore` file that allows the `build` folder to exist when installing from `npm` on newer versions of node

No way to test other than publishing, since installing from git commit ignores this behavior.