### PR TITLE
Safely _.get credentials from args

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -8,9 +8,12 @@ import * as logger from '../services/logger';
 import * as cache from '../services/cache-env';
 
 async function resolveCredentials(args) {
-  if (args.credentials) {
+  const credentials = _.get(args, 'credentials');
+
+  if (credentials) {
     return await parseCredentials(args.credentials)
   }
+
   return await promptUserCredentials(args);
 }
 


### PR DESCRIPTION
Resolves issue with the following error message:
`Cannot read property 'credentials' of undefined`
Being given instead of prompting the user to log in as intended.