### PR TITLE
Check for required files before packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "prepare": "npm run build",
+    "preinstall": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "preinstall": "npm run build",
+    "prepare": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/src/clients/auth-service.js
+++ b/src/clients/auth-service.js
@@ -33,7 +33,7 @@ const tokensUrl = new URI(services.authService).segment('/v1/auth/tokens').toStr
 const appAccessTokenUrl = new URI(services.authService).segment('/v1/auth/tokens').toString();
 
 function getBasicAuthHeaderValue(email, password) {
-  return 'Basic ' + new Buffer(`${email}:${password}`).toString('base64');
+  return 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64');
 }
 
 export async function createRefreshToken(email, password) {

--- a/src/services/error-handler.js
+++ b/src/services/error-handler.js
@@ -39,10 +39,8 @@ export function getErrorMessage(err) {
       if (body.errors) {
         return getJsonApiErrorMessage(body.errors);
       }
-    } catch (err){
-    }
+    } catch (err) {}
   }
-
 
   return 'Unrecognized error. Run `shoutem last-error` for additional details.'
 }
@@ -62,7 +60,7 @@ export async function handleError(err) {
       errorJson.message = (err || {}).message;
       await cache.setValue('last-error', errorJson);
       if (!reportInfoPrinted) {
-        console.error(`\nUse ${'shoutem last-error'.cyan} for more info`);
+        console.error(`\nUse ${'shoutem last-error'.cyan} for more information.`);
         reportInfoPrinted = true;
       }
   } catch (err) {

--- a/src/shoutem.js
+++ b/src/shoutem.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 require('colors');
 const path = require('path');

--- a/src/user_messages.js
+++ b/src/user_messages.js
@@ -48,7 +48,7 @@ export default {
   },
   push: {
     complete: () => 'Success!'.green.bold,
-    missingRequiredFile: (file, extTitle) => `Missing ${file}, cannot push ${extTitle.cyan}.`,
+    missingRequiredFile: (fileName, extName) => `Canceling push, extension '${extName}' is missing '${fileName}' file.`,
     missingPackageJson: list => `Warning: directories ${list} couldn't be pushed due to missing package.json.`,
     failureSuggestion: () => 'Warning: Check whether both server and app directory have a valid package.json file.',
     uploadingInfo: (extJson, env) =>

--- a/src/user_messages.js
+++ b/src/user_messages.js
@@ -48,6 +48,7 @@ export default {
   },
   push: {
     complete: () => 'Success!'.green.bold,
+    missingRequiredFile: (file, extTitle) => `Missing ${file}, cannot push ${extTitle.cyan}.`,
     missingPackageJson: list => `Warning: directories ${list} couldn't be pushed due to missing package.json.`,
     failureSuggestion: () => 'Warning: Check whether both server and app directory have a valid package.json file.',
     uploadingInfo: (extJson, env) =>


### PR DESCRIPTION
Before attempting to upload the extension, the app will first check if it has all the required files in order to function as intended, which are:
- `app/index.js`
- `app/package.json`
- `server/package.json`

Something to note:
I've added a `--no-deprecation` flag to `shoutem.js` in order to avoid getting a confusing deprecation warning about Buffer. As you can see from the diff, I did address the use of Buffer in the CLI, however, a plethora of dependencies still utilize the old syntax which causes the deprecation warning.

I have no idea why the warning happens when I throw an error in the place I'm throwing an error. If anyone has a better suggestion on how to suppress the warning without hiding all deprecations (as updating dependencies has been unsuccessful in resolving it), I am more than happy to try it out if I haven't already.

This now works for individual and multiple extension pushing and publishing:
```
shoutem push dev-name.empty-app dev-name.valid-ext
? Check which extensions you want to push to production. (Press <space> to select)
dev-name.empty-app
dev-name.valid-ext
Pushing Empty-app:
Checking for required files...

Canceling push, extension 'Empty-app' is missing 'app/index.js' file.

Use shoutem last-error for more information.
Pushing Valid-ext:
Checking for required files...[OK]
Checking the extension code for syntax errors...[OK]
Building the server part... [OK]
Building the app part... [OK]
Packing extension... [OK]
Processing upload... [OK]
Uploading Valid-ext extension to Shoutem... [OK]
Success!
Pushed:
  dev-name.valid-ext
Not pushed:
  dev-name.empty-app
```