### PR TITLE
Feature/remove en json and add messaging and example

### DIFF
--- a/src/cli/page/add.js
+++ b/src/cli/page/add.js
@@ -19,4 +19,5 @@ export async function createPage(opts, extensionPath) {
   const changes = await instantiateExtensionTemplate('settings-page', { ...opts, extensionPath, developer });
   await offerChanges(changes);
   console.log('Success'.green.bold);
+  console.log('Remember to create \'server/translations/en.json\' add your translation strings to it.\nYou can use example.json to check the format.');
 }

--- a/src/cli/page/add.js
+++ b/src/cli/page/add.js
@@ -19,5 +19,5 @@ export async function createPage(opts, extensionPath) {
   const changes = await instantiateExtensionTemplate('settings-page', { ...opts, extensionPath, developer });
   await offerChanges(changes);
   console.log('Success'.green.bold);
-  console.log('Remember to create \'server/translations/en.json\' add your translation strings to it.\nYou can use example.json to check the format.');
+  console.log('Remember to create \'server/translations/en.json\' add your translation strings to it.\nYou can use \'server/translations/example.json\' to check the format.');
 }

--- a/src/cli/page/add.js
+++ b/src/cli/page/add.js
@@ -19,5 +19,5 @@ export async function createPage(opts, extensionPath) {
   const changes = await instantiateExtensionTemplate('settings-page', { ...opts, extensionPath, developer });
   await offerChanges(changes);
   console.log('Success'.green.bold);
-  console.log('Remember to create \'server/translations/en.json\' add your translation strings to it.\nYou can use \'server/translations/example.json\' to check the format.');
+  console.log('Remember to create \'server/translations/en.json\' and add your translation strings to it.\nYou can use \'server/translations/example.json\' to check the format.');
 }

--- a/src/services/extension-template.js
+++ b/src/services/extension-template.js
@@ -11,6 +11,6 @@ export async function instantiateExtensionTemplate(localTemplatePath, context, o
   }
 
   await template.instantiateTemplatePath(localTemplatePath, context.extensionPath, context, opts);
-  
+
   return await template.instantiateTemplatePath('extension-js', context.extensionPath, context, opts);
 }

--- a/src/templates/settings-page-react-extension/server/translations/en.json
+++ b/src/templates/settings-page-react-extension/server/translations/en.json
@@ -1,9 +1,0 @@
-{
-  "{{developer.name}}": {
-    "{{extJson.name}}": {
-      "extension-page.save-button": "Save",
-      "extension-page.enter-company-name": "Enter company name",
-      "extension-page.company": "Company:"
-    }
-  }
-}

--- a/src/templates/settings-page-react-extension/server/translations/example.json
+++ b/src/templates/settings-page-react-extension/server/translations/example.json
@@ -1,6 +1,9 @@
 {
   "{{developer.name}}": {
     "{{extJson.name}}": {
+      "extension-page.save-button": "Save",
+      "extension-page.enter-company-name": "Enter company name",
+      "extension-page.company": "Company:",
       "shortcut-page.save-button": "Save",
       "shortcut-page.choose-your-greeting": "Choose your greeting",
       "shortcut-page.name": "Name:"

--- a/src/templates/settings-page-react-shortcut/server/translations/example.json
+++ b/src/templates/settings-page-react-shortcut/server/translations/example.json
@@ -1,0 +1,12 @@
+{
+  "{{developer.name}}": {
+    "{{extJson.name}}": {
+      "extension-page.save-button": "Save",
+      "extension-page.enter-company-name": "Enter company name",
+      "extension-page.company": "Company:",
+      "shortcut-page.save-button": "Save",
+      "shortcut-page.choose-your-greeting": "Choose your greeting",
+      "shortcut-page.name": "Name:"
+    }
+  }
+}


### PR DESCRIPTION
- added message to create and fill out `en.json`
- added example file for developers to utilize (`example.json`)

This will be handled properly later down the line with a separate improvement task for appendable template file.

Open to suggestions about the messaging and possibly the `example.json` file.

Can be tested with `npm i -g shoutem/cli#47f9bbd`