### PR TITLE
Feature/seext 9440 retry downloading extensions if download fails during shoutem clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "prepare": "npm run build",
+    "preinstall": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel ./src --ignore ./src/templates --out-dir build --source-maps inline --copy-files",
     "extlint": "eslint",
     "lint": "eslint ./ --ignore-pattern build --ignore-pattern templates",
-    "preinstall": "npm run build",
+    "prepare": "npm run build",
     "shoutem": "node build/shoutem.js",
     "test": "mocha -R spec --require fetch-everywhere --compilers js:babel-core/register \"src/**/*spec.js\""
   },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@shoutem/cli",
-<<<<<<< HEAD
-  "version": "0.13.11",
-=======
   "version": "0.13.12",
->>>>>>> release/0.13.12
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -35,22 +35,20 @@ export async function pullExtensions(appId, destinationDir) {
 }
 
 async function pullExtension(destinationDir, { extension, canonicalName }) {
-  let pullSuccessful = false;
-  let pullError;
+  let pullError = {};
   for (let i = 0; i < 4; i++) {
     try {
       const url = await getExtensionUrl(extension);
       const tgzDir = (await tmp.dir()).path;
       await downloadFile(url, { directory: tgzDir, filename: 'extension.tgz' });
       await shoutemUnpack(path.join(tgzDir, 'extension.tgz'), path.join(destinationDir, canonicalName));
-      return;
     } catch (error) {
       pullError = error;
       console.log(`Failed to download extension ${canonicalName}, try ${i + 1}/5`);
     }
   }
 
-  if (!pullSuccessful) {
+  if (!_.isEmpty(pullError)) {
     pullError.message = `Could not fetch extension ${canonicalName}.`;
     throw new Error(pullError);
   }

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -43,7 +43,7 @@ async function pullExtension(destinationDir, { extension, canonicalName }) {
       await downloadFile(url, { directory: tgzDir, filename: 'extension.tgz' });
       await shoutemUnpack(path.join(tgzDir, 'extension.tgz'), path.join(destinationDir, canonicalName));
       pullSuccessful = true;
-    } catch {
+    } catch () {
       console.log(`Failed to download extension ${canonicalName}, try ${i + 1}/5`);
     }
   }

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -37,21 +37,23 @@ export async function pullExtensions(appId, destinationDir) {
 
 async function pullExtension(destinationDir, { extension, canonicalName }) {
   let pullError = {};
-  for (let i = 0; i < 4; i++) {
+  let pullSuccessful = false;
+  for (let i = 0; !pullSuccessful || i < 4; i++) {
     try {
       const url = await getExtensionUrl(extension);
       const tgzDir = (await tmp.dir()).path;
       await downloadFile(url, { directory: tgzDir, filename: 'extension.tgz' });
       await shoutemUnpack(path.join(tgzDir, 'extension.tgz'), path.join(destinationDir, canonicalName));
+      pullSuccessful = true;
     } catch (error) {
       pullError = error;
       console.log(`Failed to download extension ${canonicalName}, try ${i + 1}/5`);
     }
   }
 
-  if (!_.isEmpty(pullError)) {
+  if (!pullSuccessful) {
     pullError.message = `Could not fetch extension ${canonicalName}.`;
-    throw new Error(pullError);
+    throw pullError;
   }
 }
 

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -36,6 +36,7 @@ export async function pullExtensions(appId, destinationDir) {
 
 async function pullExtension(destinationDir, { extension, canonicalName }) {
   let pullSuccessful = false;
+  let pullError;
   for (i = 0; pullSuccessful || i < 4; i++) {
     try {
       const url = await getExtensionUrl(extension);
@@ -43,13 +44,15 @@ async function pullExtension(destinationDir, { extension, canonicalName }) {
       await downloadFile(url, { directory: tgzDir, filename: 'extension.tgz' });
       await shoutemUnpack(path.join(tgzDir, 'extension.tgz'), path.join(destinationDir, canonicalName));
       pullSuccessful = true;
-    } catch () {
+    } catch (error) {
+      pullError = error;
       console.log(`Failed to download extension ${canonicalName}, try ${i + 1}/5`);
     }
   }
 
   if (!pullSuccessful) {
-    throw new Error(`Could not fetch extension ${canonicalName}.`)
+    pullError.message = `Could not fetch extension ${canonicalName}.`;
+    throw new Error(pullError);
   }
 }
 

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -37,13 +37,13 @@ export async function pullExtensions(appId, destinationDir) {
 async function pullExtension(destinationDir, { extension, canonicalName }) {
   let pullSuccessful = false;
   let pullError;
-  for (i = 0; pullSuccessful || i < 4; i++) {
+  for (let i = 0; i < 4; i++) {
     try {
       const url = await getExtensionUrl(extension);
       const tgzDir = (await tmp.dir()).path;
       await downloadFile(url, { directory: tgzDir, filename: 'extension.tgz' });
       await shoutemUnpack(path.join(tgzDir, 'extension.tgz'), path.join(destinationDir, canonicalName));
-      pullSuccessful = true;
+      return;
     } catch (error) {
       pullError = error;
       console.log(`Failed to download extension ${canonicalName}, try ${i + 1}/5`);

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import _ from 'lodash';
 import mkdirp from 'mkdirp-promise';
 import tmp from 'tmp-promise';
 import rmrf from 'rmfr';


### PR DESCRIPTION
This PR would implement a simple loop that tries to download an exension up to 5 times before reporting an error.

This should improve the consistency of downloading extensions on less stable network connections.

Can be tried with `npm i -g shoutem/cli#76300a1`, or whatever the latest commit's short-hash.