### PR TITLE
SEEXT-10691

### DIFF
--- a/src/services/extlint/index.js
+++ b/src/services/extlint/index.js
@@ -6,6 +6,7 @@ export default async function(extPath) {
     path.join(extPath, '**/*.js'),
     path.join(extPath, '**/*.jsx'),
     '--no-eslintrc',
+    '--no-error-on-unmatched-pattern',
     '--config',
     path.join(__dirname, 'extension-check-eslint-config.json'),
     '--ignore-pattern',

--- a/src/services/template.js
+++ b/src/services/template.js
@@ -13,6 +13,7 @@ export function load(pathWithSlashes, templateContext) {
   return Mustache.render(template, templateContext);
 }
 
+// eslint-disable-next-line consistent-return
 async function instantiateTemplatePathRec(
   localTemplatePath,
   destinationPath,
@@ -20,7 +21,7 @@ async function instantiateTemplatePathRec(
   opts,
 ) {
   if (localTemplatePath.endsWith('template-init.js')) {
-    return;
+    return null;
   }
 
   const resolvedDestinationPath = Mustache.render(destinationPath, context);
@@ -35,8 +36,7 @@ async function instantiateTemplatePathRec(
       const src = path.join(localTemplatePath, file);
       const dest = path.join(resolvedDestinationPath, file);
 
-      instantiateTemplatePathRec(src, dest, context, opts);
-      return;
+      return instantiateTemplatePathRec(src, dest, context, opts);
     });
   } else if (templatePathState.isFile()) {
     const templateContent = await fs.readFile(templatePath, 'utf8');

--- a/src/templates/extension-js/template-init.js
+++ b/src/templates/extension-js/template-init.js
@@ -1,9 +1,11 @@
 import _ from 'lodash';
 import decamelize from 'decamelize';
-import {isReactPage} from '../settings-page-react/template-init';
+import { isReactPage } from '../settings-page-react/template-init';
 
 function importStatements(names, path, directoriesNames = names) {
-  return names.map((name, i) => `import ${name} from '${path}/${directoriesNames[i]}';`).join('\n');
+  return names
+    .map((name, i) => `import ${name} from '${path}/${directoriesNames[i]}';`)
+    .join('\n');
 }
 
 function indentedNamesList(names) {
@@ -25,10 +27,15 @@ export async function before(context) {
   const themesImports = importStatements(themesNamesList, './themes');
   const themesNames = indentedNamesList(themesNamesList);
 
-
   const pagesNamesList = _.map(_.filter(extJson.pages, isReactPage), 'name');
-  const pagesDirectoriesList = pagesNamesList.map(name => decamelize(name, '-'));
-  const pagesImports = importStatements(pagesNamesList, './pages', pagesDirectoriesList);
+  const pagesDirectoriesList = pagesNamesList.map(name =>
+    decamelize(name, '-'),
+  );
+  const pagesImports = importStatements(
+    pagesNamesList,
+    './pages',
+    pagesDirectoriesList,
+  );
   const pagesNames = indentedNamesList(pagesNamesList);
 
   const extJsonString = JSON.stringify(extJson, null, 2);

--- a/src/templates/init/template-init.js
+++ b/src/templates/init/template-init.js
@@ -1,7 +1,10 @@
 import path from 'path';
-import 'colors'
+import 'colors';
 
 export async function before(context) {
   const { devName, extJson, extensionPath } = context;
-  context.extensionPath = path.join(extensionPath, `${devName}.${extJson.name}`);
+  context.extensionPath = path.join(
+    extensionPath,
+    `${devName}.${extJson.name}`,
+  );
 }

--- a/src/templates/screen/template-init.js
+++ b/src/templates/screen/template-init.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import getOrSet from 'lodash-get-or-set';
-import camelcase from 'uppercamelcase';
 import * as shortcut from '../../services/shortcut';
 
 export async function before(context) {

--- a/src/templates/settings-page-html/template-init.js
+++ b/src/templates/settings-page-html/template-init.js
@@ -4,7 +4,7 @@ import getOrSet from 'lodash-get-or-set';
 import { instantiateExtensionTemplate } from '../../services/extension-template';
 
 function isHtmlPage({ type, path }) {
-   return type === 'html' && !_.includes(path, 'server/build');
+  return type === 'html' && !_.includes(path, 'server/build');
 }
 
 export async function before(context) {
@@ -12,7 +12,9 @@ export async function before(context) {
   const pages = getOrSet(extJson, 'pages', []);
 
   if (!_.every(pages, isHtmlPage)) {
-    throw new Error('Html pages can\'t be mixed with non-html settings pages in the same extension');
+    throw new Error(
+      "Html pages can't be mixed with non-html settings pages in the same extension",
+    );
   }
 
   if (_.find(pages, { name })) {
@@ -26,11 +28,11 @@ export async function before(context) {
   pages.push({
     name: pageName,
     path: `server/pages/${pageDirectoryName}/index.html`,
-    type: 'html'
+    type: 'html',
   });
 
   if (extensionScope) {
-    await instantiateExtensionTemplate('settings-page-html-extension', context)
+    await instantiateExtensionTemplate('settings-page-html-extension', context);
   } else {
     await instantiateExtensionTemplate('settings-page-html-shortcut', context);
   }

--- a/src/templates/settings-page-react-bin/template-init.js
+++ b/src/templates/settings-page-react-bin/template-init.js
@@ -1,3 +1,4 @@
+/* eslint prettier/prettier: 0 */
 import _ from 'lodash';
 import path from 'path';
 import getOrSet from 'lodash-get-or-set';

--- a/src/templates/settings-page-react/template-init.js
+++ b/src/templates/settings-page-react/template-init.js
@@ -18,7 +18,9 @@ export async function before(context) {
   }
 
   if (!_.every(pages, isReactPage)) {
-    throw new Error('React pages can\'t be mixed with non-react settings pages in the same extension');
+    throw new Error(
+      "React pages can't be mixed with non-react settings pages in the same extension",
+    );
   }
 
   pages.push({ name, type: 'react-page' });
@@ -30,7 +32,10 @@ export async function before(context) {
 
 export async function after(context) {
   if (context.extensionScope) {
-    await instantiateExtensionTemplate('settings-page-react-extension', context);
+    await instantiateExtensionTemplate(
+      'settings-page-react-extension',
+      context,
+    );
   } else {
     await instantiateExtensionTemplate('settings-page-react-shortcut', context);
   }

--- a/src/templates/settings-page/template-init.js
+++ b/src/templates/settings-page/template-init.js
@@ -3,10 +3,18 @@ import { instantiateExtensionTemplate } from '../../services/extension-template'
 import { linkSettingsPageWithExistingScreen } from '../../services/shortcut';
 
 export async function after(context) {
-  const { type, extensionScope, extJson, existingScreenName, newScreen, name, title } = context;
+  const {
+    type,
+    extensionScope,
+    extJson,
+    existingScreenName,
+    newScreen,
+    name,
+    title,
+  } = context;
 
   if (type === 'react') {
-    await instantiateExtensionTemplate('settings-page-react', context)
+    await instantiateExtensionTemplate('settings-page-react', context);
   } else if (type === 'html') {
     await instantiateExtensionTemplate('settings-page-html', context);
   } else if (type === 'blank') {
@@ -16,8 +24,7 @@ export async function after(context) {
   }
 
   if (extensionScope) {
-    getOrSet(extJson, 'settingsPages', [])
-      .push({ page: `@.${name}`, title });
+    getOrSet(extJson, 'settingsPages', []).push({ page: `@.${name}`, title });
 
     return;
   }

--- a/src/templates/shortcut/template-init.js
+++ b/src/templates/shortcut/template-init.js
@@ -1,4 +1,4 @@
-import {addShortcut} from '../../services/shortcut';
+import { addShortcut } from '../../services/shortcut';
 
 export async function before(context) {
   addShortcut(context.extJson, context);

--- a/src/templates/theme/template-init.js
+++ b/src/templates/theme/template-init.js
@@ -4,7 +4,9 @@ import getOrSet from 'lodash-get-or-set';
 export async function before({ title, themeName, description, extJson }) {
   const themes = getOrSet(extJson, 'themes', []);
   if (_.find(themes, { name: themeName })) {
-    throw new Error(`Theme \`${themeName}\` already exists. Pick another name.`);
+    throw new Error(
+      `Theme \`${themeName}\` already exists. Pick another name.`,
+    );
   }
   themes.push({
     title,
@@ -14,14 +16,13 @@ export async function before({ title, themeName, description, extJson }) {
     variables: `@.${themeName}Variables`,
   });
 
-  getOrSet(extJson, 'themeVariables', [])
-    .push({
-      name: `${themeName}Variables`,
-      path: `./server/themes/${themeName}Variables.json`,
-    });
+  getOrSet(extJson, 'themeVariables', []).push({
+    name: `${themeName}Variables`,
+    path: `./server/themes/${themeName}Variables.json`,
+  });
 
   return [
     `app/themes/${themeName}.js`,
-    `server/themes/${themeName}Variables.js`
+    `server/themes/${themeName}Variables.js`,
   ];
 }


### PR DESCRIPTION
- revert logic changes in services/template.js
- run lint on js files in the `templates` directory
- add `--no-error-on-unmatched-pattern` when checking extension for lint errors as we're using a newer version of eslint that throws an error if there are no files matching the given pattern
