### PR TITLE
Feature/web support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/cli",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/clients/default-package-manager.js
+++ b/src/clients/default-package-manager.js
@@ -13,7 +13,12 @@ export function setDefaultPackageManager(name) {
 
 export function getDefaultPackageManager() {
   try {
-    return fs.readFileSync(defaultPackageManagerFilePath, 'utf8');
+    // Disable bun in favour of npm for the time being
+    const resolvedManager = fs.readFileSync(
+      defaultPackageManagerFilePath,
+      'utf8',
+    );
+    return resolvedManager === 'bun' ? 'npm' : resolvedManager;
   } catch (err) {
     setDefaultPackageManager('npm');
     return 'npm';

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -21,9 +21,6 @@ import { ensureUserIsLoggedIn } from '../commands/login';
 import confirmer from './confirmer';
 const mv = Promise.promisify(require('mv'));
 
-// BUN doesn't support pack at the moment, so in that case we default to npm
-const resolvedPacker = packageManager === 'bun' ? 'npm' : packageManager;
-
 function hasPackageJson(dir) {
   return pathExists(path.join(dir, 'package.json'));
 }
@@ -46,7 +43,7 @@ async function packageManagerPack(dir, destinationDir) {
     : packageJson.dependencies;
 
   await writeJsonFile(packageJson, packageJsonPath);
-  const { stdout } = await exec(`${resolvedPacker} pack`, { cwd: appDir });
+  const { stdout } = await exec(`${packageManager} pack`, { cwd: appDir });
   const packageFilename = stdout.replace(/\n$/, '');
   const packagePath = path.join(appDir, packageFilename);
 

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -21,6 +21,9 @@ import { ensureUserIsLoggedIn } from '../commands/login';
 import confirmer from './confirmer';
 const mv = Promise.promisify(require('mv'));
 
+// BUN doesn't support pack at the moment, so in that case we default to npm
+const resolvedPacker = packageManager === 'bun' ? 'npm' : packageManager;
+
 function hasPackageJson(dir) {
   return pathExists(path.join(dir, 'package.json'));
 }
@@ -41,7 +44,7 @@ async function packageManagerPack(dir, destinationDir) {
   packageJson.dependencies = isWeb ? packageJson.webDependencies : packageJson.dependencies;
 
   await writeJsonFile(packageJson, packageJsonPath);
-  const { stdout } = await exec(`${packageManager} pack`, { cwd: appDir });
+  const { stdout } = await exec(`${resolvedPacker} pack`, { cwd: appDir });
   const packageFilename = stdout.replace(/\n$/, '');
   const packagePath = path.join(dir, packageFilename);
 

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -48,7 +48,7 @@ async function packageManagerPack(dir, destinationDir) {
   await writeJsonFile(packageJson, packageJsonPath);
   const { stdout } = await exec(`${resolvedPacker} pack`, { cwd: appDir });
   const packageFilename = stdout.replace(/\n$/, '');
-  const packagePath = path.join(dir, packageFilename);
+  const packagePath = path.join(appDir, packageFilename);
 
   await mv(packagePath, resultFilename);
 


### PR DESCRIPTION
- build web package for extension that have webDependencies declared
- this package is downloaded and used when cloning the app and fetching extension code remotely
- disable bun in CLI, and default to npm when bun is set as default package manager