### PR TITLE
Release/0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.15.2",
-  "lockfileVersion": 3,
+  "version": "0.16.0",
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/cli",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/clients/default-package-manager.js
+++ b/src/clients/default-package-manager.js
@@ -13,7 +13,12 @@ export function setDefaultPackageManager(name) {
 
 export function getDefaultPackageManager() {
   try {
-    return fs.readFileSync(defaultPackageManagerFilePath, 'utf8');
+    // Disable bun in favour of npm for the time being
+    const resolvedManager = fs.readFileSync(
+      defaultPackageManagerFilePath,
+      'utf8',
+    );
+    return resolvedManager === 'bun' ? 'npm' : resolvedManager;
   } catch (err) {
     setDefaultPackageManager('npm');
     return 'npm';


### PR DESCRIPTION
- added support for web segment in extensions
- added fallback to `npm` when using `bun`