### PR TITLE
Hotfix/0.16.3 -> develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/cli",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Command-line tools for Shoutem applications",
   "repository": {
     "type": "git",

--- a/src/services/packer.js
+++ b/src/services/packer.js
@@ -6,11 +6,11 @@ import _ from 'lodash';
 import Promise from 'bluebird';
 import tmp from 'tmp-promise';
 import targz from 'tar.gz';
+import rmrf from 'rmfr';
+import decompress from 'decompress';
 import { buildNodeProject } from './node';
 import { writeJsonFile, readJsonFile } from './data';
 import { spinify } from './spinner';
-import rmrf from 'rmfr';
-import decompress from 'decompress';
 import { loadExtensionJson } from './extension';
 import {
   packageManager,
@@ -19,6 +19,7 @@ import {
 } from './package-manager-service';
 import { ensureUserIsLoggedIn } from '../commands/login';
 import confirmer from './confirmer';
+
 const mv = Promise.promisify(require('mv'));
 
 function hasPackageJson(dir) {
@@ -29,7 +30,7 @@ async function packageManagerPack(dir, destinationDir) {
   const component = path.basename(dir);
   const resultFilename = path.join(destinationDir, `${component}.tgz`);
   const isWeb = component === 'web';
-  const appDir = isWeb ? dir.replace('web', 'app') : dir;
+  const appDir = isWeb ? dir.replace('/web', '/app') : dir;
 
   const packageJsonPath = path.join(appDir, 'package.json');
 


### PR DESCRIPTION
When packing the web segment, we actually want to pack the app with the changed dependencies array. So, we replaced the web with `app` to resolve the path properly. However, in case of extensions that have web in their name, this would replace the wrong string :D

This change should resolve this issue